### PR TITLE
Add checks for isLoggedIn for notifications + Add checks for onDuty officers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ Information about each parameter is in the file.
 
 * Hunting Zones
 * Locales for alerts
-* Add onduty check for alerts
 * Vehicle Theft Alert

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -5,11 +5,10 @@ QBCore = exports['qb-core']:GetCoreObject()
 
 -- core related
 
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
     isLoggedIn = true
-    PlayerData= QBCore.Functions.GetPlayerData()
-    PlayerJob  = QBCore.Functions.GetPlayerData().job
-    -- generateHuntingZones()
+    PlayerData = QBCore.Functions.GetPlayerData()
+    PlayerJob = QBCore.Functions.GetPlayerData().job
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
@@ -20,7 +19,8 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     -- removeHuntingZones()
 end)
 
-RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
+RegisterNetEvent("QBCore:Client:OnJobUpdate", function(JobInfo)
+    PlayerData = QBCore.Functions.GetPlayerData()
     PlayerJob = JobInfo
 end)
 

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -1,11 +1,12 @@
 PlayerData = {}
 PlayerJob = {}
-
+isLoggedIn = false
 QBCore = exports['qb-core']:GetCoreObject()
 
 -- core related
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    isLoggedIn = true
     PlayerData= QBCore.Functions.GetPlayerData()
     PlayerJob  = QBCore.Functions.GetPlayerData().job
     -- generateHuntingZones()
@@ -13,6 +14,7 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 	PlayerData = {}
+    isLoggedIn = false
     currentCallSign = ""
     -- currentVehicle, inVehicle, currentlyArmed, currentWeapon = nil, false, false, `WEAPON_UNARMED`
     -- removeHuntingZones()
@@ -198,7 +200,7 @@ RegisterNetEvent('dispatch:manageNotifs', function(sentSetting)
 end)
 
 RegisterNetEvent('dispatch:clNotify', function(sNotificationData, sNotificationId, sender)
-    if sNotificationData ~= nil and LocalPlayer.state.isLoggedIn then
+    if sNotificationData ~= nil and isLoggedIn then
 		if IsValidJob(sNotificationData['job']) then
             if not disableNotis then
 				if sNotificationData.origin ~= nil then

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -175,6 +175,13 @@ local function IsValidJob(jobList)
 	return false
 end
 
+local function CheckOnDuty()
+	if Config.OnDutyOnly then
+		return PlayerJob.onduty
+	end
+	return true
+end
+
 -- Dispatch Itself
 
 local disableNotis, disableNotifSounds = false, false
@@ -201,7 +208,7 @@ end)
 
 RegisterNetEvent('dispatch:clNotify', function(sNotificationData, sNotificationId, sender)
     if sNotificationData ~= nil and isLoggedIn then
-		if IsValidJob(sNotificationData['job']) then
+		if IsValidJob(sNotificationData['job']) and CheckOnDuty() then
             if not disableNotis then
 				if sNotificationData.origin ~= nil then
 					SendNUIMessage({

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -1,22 +1,11 @@
 PlayerData = {}
 PlayerJob = {}
-isLoggedIn = false
+
 QBCore = exports['qb-core']:GetCoreObject()
-
-
-CreateThread(function()
-    while QBCore == nil do
-        Wait(200)
-    end
-    isLoggedIn = true
-    PlayerData = QBCore.Functions.GetPlayerData()
-    PlayerJob  = QBCore.Functions.GetPlayerData().job
-end)
 
 -- core related
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    isLoggedIn = true
     PlayerData= QBCore.Functions.GetPlayerData()
     PlayerJob  = QBCore.Functions.GetPlayerData().job
     -- generateHuntingZones()
@@ -24,7 +13,6 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 	PlayerData = {}
-    isLoggedIn = false
     currentCallSign = ""
     -- currentVehicle, inVehicle, currentlyArmed, currentWeapon = nil, false, false, `WEAPON_UNARMED`
     -- removeHuntingZones()
@@ -210,7 +198,7 @@ RegisterNetEvent('dispatch:manageNotifs', function(sentSetting)
 end)
 
 RegisterNetEvent('dispatch:clNotify', function(sNotificationData, sNotificationId, sender)
-    if sNotificationData ~= nil then
+    if sNotificationData ~= nil and LocalPlayer.state.isLoggedIn then
 		if IsValidJob(sNotificationData['job']) then
             if not disableNotis then
 				if sNotificationData.origin ~= nil then

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,9 @@ Config.Timer = {}
 
 Config.PoliceJob = { "police", "bcso"}
 
+-- Enable if you only want to send alerts to onDuty officers
+Config.OnDutyOnly = false
+
 Config.PoliceAndAmbulance = { "police", "ambulance", "bcso"}
 Config.PhoneModel = 'prop_npc_phone_02'
 


### PR DESCRIPTION
- Fixes the issue where the alert is being sent to a player who hasn't logged in as a character yet.
- Implement onDuty only alerts. Can be enabled / disabled using `Config.OnDutyOnly` flag. Defaults to `false` for backward compatibility