### PR TITLE
Updated anonymous call location

### DIFF
--- a/client/cl_commands.lua
+++ b/client/cl_commands.lua
@@ -124,9 +124,9 @@ RegisterCommand('911a', function(source, args, rawCommand)
                     name = "Anonymous",
                     number = "Hidden Number",
                     origin = {
-                        x = currentPos.x,
-                        y = currentPos.y,
-                        z = currentPos.z
+                        x = 759.26,
+                        y = 1274.29,
+                        z = 360.3
                     },
                     dispatchMessage = "Incoming Anonymous Call", -- message
                     information = msg,
@@ -210,9 +210,9 @@ RegisterCommand('311a', function(source, args, rawCommand)
                     name = "Anonymous",
                     number = "Hidden Number",
                     origin = {
-                        x = currentPos.x,
-                        y = currentPos.y,
-                        z = currentPos.z
+                        x = 759.26,
+                        y = 1274.29,
+                        z = 360.3
                     },
                     dispatchMessage = "Incoming Call", -- message
                     information = msg,


### PR DESCRIPTION
Made the anonymous calls location come from a cellphone tower near the vinewood sign. This adds more of a "VPN" basis when making anon calls rather than sending the exact location of that user, kind of removes the purpose for anon calls. 

Made phone call from my current location and it pings at 719 as per photo
![image](https://nooby.xyz/nooby/i/HaAnJs-02-06-2022.png)
