### PR TITLE
Event Handler for resource start. PlayerData/PlayerJob

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -6,6 +6,14 @@ local blips = {}
 
 -- core related
 
+AddEventHandler('onResourceStart', function(resourceName)
+    if GetCurrentResourceName() == resourceName then
+		isLoggedIn = true
+        PlayerData = QBCore.Functions.GetPlayerData()
+        PlayerJob = QBCore.Functions.GetPlayerData().job
+    end
+end)
+
 RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
     isLoggedIn = true
     PlayerData = QBCore.Functions.GetPlayerData()


### PR DESCRIPTION
Added an event handler for resource start. This just makes it easier for it to automatically recognize your job after restarting the resource for when you're setting up officer alerts.

Quality of life change.