### PR TITLE
FIXED - Blips and Sounds

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -233,9 +233,8 @@ RegisterNetEvent('dispatch:clNotify', function(sNotificationData, sNotificationI
     end
 end)
 
-RegisterNetEvent("ps-dispatch:client:AddCallBlip")
-AddEventHandler("ps-dispatch:client:AddCallBlip", function(coords, data, blipId)
-	if IsValidJob(data.recipientList) then
+RegisterNetEvent("ps-dispatch:client:AddCallBlip", function(coords, data, blipId)
+	if IsValidJob(data.recipientList) and CheckOnDuty() then
 		PlaySound(-1, data.sound, data.sound2, 0, 0, 1)
 		TriggerServerEvent("InteractSound_SV:PlayOnSource", data.sound, 0.25) -- For Custom Sounds
 		CreateThread(function()


### PR DESCRIPTION
This fixes the issue that was occurring when developers would disable the alerts for Off Duty Members but would still send sound and blips to the locations. Hopefully this clears up any issues people were having