### PR TITLE
Remove Client Loops For Handlers

### DIFF
--- a/client/cl_eventhandlers.lua
+++ b/client/cl_eventhandlers.lua
@@ -1,0 +1,129 @@
+local vehicleWhitelist = {[0]=true,[1]=true,[2]=true,[3]=true,[4]=true,[5]=true,[6]=true,[7]=true,[8]=true,[9]=true,[10]=true,[11]=true,[12]=true,[17]=true,[19]=true,[20]=true}
+
+local function isPlayerAWitness(witnesses)
+    for k, v in pairs(witnesses) do
+        if v == PlayerPedId() then
+            return true
+        end
+    end
+    return false
+end
+
+---Event that is triggered for gunshots.
+---@param witnesses table  array of peds that witnessed the shots
+---@param ped number  the ped that shot the gun
+AddEventHandler("CEventGunShot", function(witnesses, ped)
+    -- The ped that shot the gun must be the player.
+    if PlayerPedId() ~= ped then return end
+    -- This event can be triggered multiple times for a single gunshot, so we only want to run the code once.
+    -- If there are no witnesses, then the player is the shooter.
+    -- Else if there are witnesses, then the player will also be in that table.
+    -- If one of these conditions are met, then we can continue.
+    if witnesses and not isPlayerAWitness(witnesses) then return end
+    if not isPlayerWhitelisted or Config.Debug then
+        for k, v in pairs(Config.Timer) do
+            if v > 0 then Config.Timer[k] = v - 1 end
+        end
+        local vehicle = GetVehiclePedIsUsing(ped, true)
+        if vehicle ~= 0 then
+            if vehicleWhitelist[GetVehicleClass(vehicle)] then
+                local driver = GetPedInVehicleSeat(vehicle, -1)
+                if Config.Timer['Shooting'] == 0 and not BlacklistedWeapon(ped) and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
+                    if IsPedShooting(ped) then
+                        local vehicle = vehicleData(vehicle)
+                        exports['ps-dispatch']:VehicleShooting(vehicle)
+                        Config.Timer['Shooting'] = Config.Shooting.Success
+                    else
+                        Config.Timer['Shooting'] = Config.Shooting.Fail
+                    end
+                end
+            end
+        else
+            if Config.Timer['Shooting'] == 0  and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
+                if IsPedShooting(ped) and not BlacklistedWeapon(ped) then
+                    exports['ps-dispatch']:Shooting()
+                    Config.Timer['Shooting'] = Config.Shooting.Success
+                else
+                    Config.Timer['Shooting'] = Config.Shooting.Fail
+                end
+            end
+        end
+    end
+end)
+
+---@param witnesses table | Array of entity handles who witnessed the event
+---@param ped number | Entity handle of the ped who triggered the event
+---@param x number | X coord of ped
+---@param y number | Y coord of ped
+---@param z number | Z coord of ped
+AddEventHandler('CEventShockingMadDriver', function(ped, witnesses, x, y, z)
+    -- The ped that shot the gun must be the player.
+    if PlayerPedId() ~= ped then return end
+    if witnesses and not isPlayerAWitness(witnesses) then return end
+    if not isPlayerWhitelisted or Config.Debug then
+        for k, v in pairs(Config.Timer) do
+            if v > 0 then Config.Timer[k] = v - 1 end
+        end
+        local vehicle = GetVehiclePedIsUsing(ped, true)
+        local driver = GetPedInVehicleSeat(vehicle, -1)
+        if vehicleWhitelist[GetVehicleClass(vehicle)] then
+            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
+                Wait(400)
+                if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
+                    local vehicle = vehicleData(vehicle)
+                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
+                    Config.Timer['Speeding'] = Config.Speeding.Success
+                end
+            else
+                Config.Timer['Speeding'] = Config.Speeding.Fail
+            end
+        end
+    end
+end)
+
+---@param witnesses table | Array of entity handles who witnessed the event
+---@param ped number | Entity handle of the ped who triggered the event
+---@param x number | X coord of ped
+---@param y number | Y coord of ped
+---@param z number | Z coord of ped
+AddEventHandler('CEventShockingMadDriverExtreme', function(ped, witnesses, x, y, z)
+    -- The ped that shot the gun must be the player.
+    if PlayerPedId() ~= ped then return end
+    if witnesses and not isPlayerAWitness(witnesses) then return end
+    if not isPlayerWhitelisted or Config.Debug then
+        for k, v in pairs(Config.Timer) do
+            if v > 0 then Config.Timer[k] = v - 1 end
+        end
+        local vehicle = GetVehiclePedIsUsing(ped, true)
+        local driver = GetPedInVehicleSeat(vehicle, -1)
+        if vehicleWhitelist[GetVehicleClass(vehicle)] then
+            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
+                Wait(400)
+                if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
+                    local vehicle = vehicleData(vehicle)
+                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
+                    Config.Timer['Speeding'] = Config.Speeding.Success
+                end
+            else
+                Config.Timer['Speeding'] = Config.Speeding.Fail
+            end
+        end
+    end
+end)
+
+---@param witnesses table | Array of peds that witnessed the event, where witness[1] is the victim
+---@param attacker number | The ped that attacked the victim
+AddEventHandler('CEventMeleeAction', function(witnesses, attacker)
+	-- The ped that shot the gun must be the player.
+    if PlayerPedId() ~= ped then return end
+    if witnesses and not isPlayerAWitness(witnesses) then return end
+    if not isPlayerWhitelisted or Config.Debug then
+        for k, v in pairs(Config.Timer) do
+            if v > 0 then Config.Timer[k] = v - 1 end
+        end
+        if Config.Timer['Melee'] == 0 then
+            exports['ps-dispatch']:Fight()
+            Config.Timer['Melee'] = Config.Melee.Success
+        end
+    end
+end)

--- a/client/cl_eventhandlers.lua
+++ b/client/cl_eventhandlers.lua
@@ -9,7 +9,6 @@ local function isPlayerAWitness(witnesses)
     return false
 end
 
----Event that is triggered for gunshots.
 ---@param witnesses table  array of peds that witnessed the shots
 ---@param ped number  the ped that shot the gun
 AddEventHandler("CEventGunShot", function(witnesses, ped)

--- a/client/cl_eventhandlers.lua
+++ b/client/cl_eventhandlers.lua
@@ -20,29 +20,30 @@ AddEventHandler("CEventGunShot", function(witnesses, ped)
     -- Else if there are witnesses, then the player will also be in that table.
     -- If one of these conditions are met, then we can continue.
     if witnesses and not isPlayerAWitness(witnesses) then return end
-    if not isPlayerWhitelisted or Config.Debug then
-        local vehicle = GetVehiclePedIsUsing(ped, true)
-        if vehicle ~= 0 then
-            if vehicleWhitelist[GetVehicleClass(vehicle)] then
-                local driver = GetPedInVehicleSeat(vehicle, -1)
-                if Config.Timer['Shooting'] == 0 and not BlacklistedWeapon(ped) and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
-                    if IsPedShooting(ped) then
-                        local vehicle = vehicleData(vehicle)
-                        exports['ps-dispatch']:VehicleShooting(vehicle)
-                        Config.Timer['Shooting'] = Config.Shooting.Success
-                    else
-                        Config.Timer['Shooting'] = Config.Shooting.Fail
-                    end
-                end
-            end
-        else
-            if Config.Timer['Shooting'] == 0  and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
-                if IsPedShooting(ped) and not BlacklistedWeapon(ped) then
-                    exports['ps-dispatch']:Shooting()
+    -- If the player is a whitelisted job, then we don't want to trigger the event.
+    -- However, if the player is not whitelisted or Debug mode is true, then we want to trigger the event.
+    if IsPoliceJob(PlayerJob.name) and not Config.Debug then return end
+    local vehicle = GetVehiclePedIsUsing(ped, true)
+    if vehicle ~= 0 then
+        if vehicleWhitelist[GetVehicleClass(vehicle)] then
+            local driver = GetPedInVehicleSeat(vehicle, -1)
+            if Config.Timer['Shooting'] == 0 and not BlacklistedWeapon(ped) and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
+                if IsPedShooting(ped) then
+                    local vehicle = vehicleData(vehicle)
+                    exports['ps-dispatch']:VehicleShooting(vehicle)
                     Config.Timer['Shooting'] = Config.Shooting.Success
                 else
                     Config.Timer['Shooting'] = Config.Shooting.Fail
                 end
+            end
+        end
+    else
+        if Config.Timer['Shooting'] == 0  and not IsPedCurrentWeaponSilenced(ped) and IsPedArmed(ped, 4) then
+            if IsPedShooting(ped) and not BlacklistedWeapon(ped) then
+                exports['ps-dispatch']:Shooting()
+                Config.Timer['Shooting'] = Config.Shooting.Success
+            else
+                Config.Timer['Shooting'] = Config.Shooting.Fail
             end
         end
     end
@@ -54,37 +55,39 @@ end)
 ---@param y number | Y coord of ped
 ---@param z number | Z coord of ped
 AddEventHandler('CEventShockingMadDriver', function(witnesses, ped, x, y, z)
-    -- The ped that shot the gun must be the player.
+    -- The ped that triggered the event must be the player.
     if PlayerPedId() ~= ped then return end
-    if not isPlayerWhitelisted or Config.Debug then
-        local vehicle = GetVehiclePedIsUsing(ped, true)
-        local driver = GetPedInVehicleSeat(vehicle, -1)
-        if vehicleWhitelist[GetVehicleClass(vehicle)] then
-            if Config.Timer['Speeding'] == 0 and ped == driver then
-                if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
-                    Wait(400)
-                    if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
-                        vehicle = vehicleData(vehicle)
-                        exports['ps-dispatch']:SpeedingVehicle(vehicle)
-                        Config.Timer['Speeding'] = Config.Speeding.Success
-                    end
-                else
-                    Config.Timer['Speeding'] = Config.Speeding.Fail
+    -- If the player is a whitelisted job, then we don't want to trigger the event.
+    -- However, if the player is not whitelisted or Debug mode is true, then we want to trigger the event.
+    if IsPoliceJob(PlayerJob.name) and not Config.Debug then return end
+    local vehicle = GetVehiclePedIsUsing(ped, true)
+    local driver = GetPedInVehicleSeat(vehicle, -1)
+    if vehicleWhitelist[GetVehicleClass(vehicle)] then
+        if Config.Timer['Speeding'] == 0 and ped == driver then
+            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
+                Wait(400)
+                if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
+                    vehicle = vehicleData(vehicle)
+                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
+                    Config.Timer['Speeding'] = Config.Speeding.Success
                 end
+            else
+                Config.Timer['Speeding'] = Config.Speeding.Fail
             end
         end
     end
 end)
 
----@param witnesses table | Array of peds that witnessed the event, where witness[1] is the victim
+---@param witnesses table | Array of peds that witnessed the event, where witnesses[1] is the victim
 ---@param attacker number | The ped that attacked the victim
 AddEventHandler('CEventMeleeAction', function(witnesses, attacker)
-	-- The ped that shot the gun must be the player.
+	-- The ped that melee attacked must be the player.
     if PlayerPedId() ~= attacker then return end
-    if not isPlayerWhitelisted or Config.Debug then
-        if Config.Timer['Melee'] == 0 then
-            exports['ps-dispatch']:Fight()
-            Config.Timer['Melee'] = Config.Melee.Success
-        end
+    -- If the player is a whitelisted job, then we don't want to trigger the event.
+    -- However, if the player is not whitelisted or Debug mode is true, then we want to trigger the event.
+    if IsPoliceJob(PlayerJob.name) and not Config.Debug then return end
+    if Config.Timer['Melee'] == 0 then
+        exports['ps-dispatch']:Fight()
+        Config.Timer['Melee'] = Config.Melee.Success
     end
 end)

--- a/client/cl_eventhandlers.lua
+++ b/client/cl_eventhandlers.lua
@@ -21,9 +21,6 @@ AddEventHandler("CEventGunShot", function(witnesses, ped)
     -- If one of these conditions are met, then we can continue.
     if witnesses and not isPlayerAWitness(witnesses) then return end
     if not isPlayerWhitelisted or Config.Debug then
-        for k, v in pairs(Config.Timer) do
-            if v > 0 then Config.Timer[k] = v - 1 end
-        end
         local vehicle = GetVehiclePedIsUsing(ped, true)
         if vehicle ~= 0 then
             if vehicleWhitelist[GetVehicleClass(vehicle)] then
@@ -56,56 +53,24 @@ end)
 ---@param x number | X coord of ped
 ---@param y number | Y coord of ped
 ---@param z number | Z coord of ped
-AddEventHandler('CEventShockingMadDriver', function(ped, witnesses, x, y, z)
+AddEventHandler('CEventShockingMadDriver', function(witnesses, ped, x, y, z)
     -- The ped that shot the gun must be the player.
     if PlayerPedId() ~= ped then return end
-    if witnesses and not isPlayerAWitness(witnesses) then return end
     if not isPlayerWhitelisted or Config.Debug then
-        for k, v in pairs(Config.Timer) do
-            if v > 0 then Config.Timer[k] = v - 1 end
-        end
         local vehicle = GetVehiclePedIsUsing(ped, true)
         local driver = GetPedInVehicleSeat(vehicle, -1)
         if vehicleWhitelist[GetVehicleClass(vehicle)] then
-            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
-                Wait(400)
-                if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
-                    local vehicle = vehicleData(vehicle)
-                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
-                    Config.Timer['Speeding'] = Config.Speeding.Success
+            if Config.Timer['Speeding'] == 0 and ped == driver then
+                if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
+                    Wait(400)
+                    if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
+                        vehicle = vehicleData(vehicle)
+                        exports['ps-dispatch']:SpeedingVehicle(vehicle)
+                        Config.Timer['Speeding'] = Config.Speeding.Success
+                    end
+                else
+                    Config.Timer['Speeding'] = Config.Speeding.Fail
                 end
-            else
-                Config.Timer['Speeding'] = Config.Speeding.Fail
-            end
-        end
-    end
-end)
-
----@param witnesses table | Array of entity handles who witnessed the event
----@param ped number | Entity handle of the ped who triggered the event
----@param x number | X coord of ped
----@param y number | Y coord of ped
----@param z number | Z coord of ped
-AddEventHandler('CEventShockingMadDriverExtreme', function(ped, witnesses, x, y, z)
-    -- The ped that shot the gun must be the player.
-    if PlayerPedId() ~= ped then return end
-    if witnesses and not isPlayerAWitness(witnesses) then return end
-    if not isPlayerWhitelisted or Config.Debug then
-        for k, v in pairs(Config.Timer) do
-            if v > 0 then Config.Timer[k] = v - 1 end
-        end
-        local vehicle = GetVehiclePedIsUsing(ped, true)
-        local driver = GetPedInVehicleSeat(vehicle, -1)
-        if vehicleWhitelist[GetVehicleClass(vehicle)] then
-            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
-                Wait(400)
-                if IsPedInAnyVehicle(ped, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
-                    local vehicle = vehicleData(vehicle)
-                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
-                    Config.Timer['Speeding'] = Config.Speeding.Success
-                end
-            else
-                Config.Timer['Speeding'] = Config.Speeding.Fail
             end
         end
     end
@@ -115,12 +80,8 @@ end)
 ---@param attacker number | The ped that attacked the victim
 AddEventHandler('CEventMeleeAction', function(witnesses, attacker)
 	-- The ped that shot the gun must be the player.
-    if PlayerPedId() ~= ped then return end
-    if witnesses and not isPlayerAWitness(witnesses) then return end
+    if PlayerPedId() ~= attacker then return end
     if not isPlayerWhitelisted or Config.Debug then
-        for k, v in pairs(Config.Timer) do
-            if v > 0 then Config.Timer[k] = v - 1 end
-        end
         if Config.Timer['Melee'] == 0 then
             exports['ps-dispatch']:Fight()
             Config.Timer['Melee'] = Config.Melee.Success

--- a/client/cl_loops.lua
+++ b/client/cl_loops.lua
@@ -1,57 +1,11 @@
---[[CreateThread(function()
-	local vehicleWhitelist = {[0]=true,[1]=true,[2]=true,[3]=true,[4]=true,[5]=true,[6]=true,[7]=true,[8]=true,[9]=true,[10]=true,[11]=true,[12]=true,[17]=true,[19]=true,[20]=true}
+CreateThread(function()
 	local sleep = 100
 	while true do
-        playerPed = PlayerPedId()
         if (not isPlayerWhitelisted or Config.Debug) then
             for k, v in pairs(Config.Timer) do
                 if v > 0 then Config.Timer[k] = v - 1 end
             end
-            if GetVehiclePedIsUsing(playerPed) ~= 0 then
-                local vehicle = GetVehiclePedIsUsing(playerPed, true)
-                    if vehicleWhitelist[GetVehicleClass(vehicle)] then
-                        local driver = GetPedInVehicleSeat(vehicle, -1)
-                        if Config.Timer['Shooting'] == 0 and not BlacklistedWeapon(playerPed) and not IsPedCurrentWeaponSilenced(playerPed) and IsPedArmed(playerPed, 4) then
-                            sleep = 10
-                            if IsPedShooting(playerPed) then
-                                local vehicle = vehicleData(vehicle)
-                                exports['ps-dispatch']:VehicleShooting(vehicle)
-                                Config.Timer['Shooting'] = Config.Shooting.Success
-                            else
-                                Config.Timer['Shooting'] = Config.Shooting.Fail
-                            end
-                        elseif Config.Timer['Speeding'] == 0 and playerPed == driver then
-                            sleep = 100
-                            if (GetEntitySpeed(vehicle) * 3.6) >= (120 + (math.random(30,60))) then
-                                Wait(400)
-                                if IsPedInAnyVehicle(playerPed, true) and ((GetEntitySpeed(vehicle) * 3.6) >= 90) then
-                                    local vehicle = vehicleData(vehicle)
-                                    exports['ps-dispatch']:SpeedingVehicle(vehicle)
-                                    Config.Timer['Speeding'] = Config.Speeding.Success
-                                end
-                            else
-                                Config.Timer['Speeding'] = Config.Speeding.Fail
-                            end
-                        else 
-                            sleep = 100 
-                        end
-                end
-            else
-                if Config.Timer['Shooting'] == 0  and not IsPedCurrentWeaponSilenced(playerPed) and IsPedArmed(playerPed, 4) then
-                    sleep = 50
-                    if IsPedShooting(playerPed) and not BlacklistedWeapon(playerPed) then
-                        exports['ps-dispatch']:Shooting()
-                        Config.Timer['Shooting'] = Config.Shooting.Success
-                    else
-                        Config.Timer['Shooting'] = Config.Shooting.Fail
-                    end
-                elseif Config.Timer['Melee'] == 0 and IsPedInMeleeCombat(playerPed) and HasPedBeenDamagedByWeapon(GetMeleeTargetForPed(playerPed), 0, 1) then
-                    sleep = 50
-                    exports['ps-dispatch']:Fight()
-                    Config.Timer['Melee'] = Config.Melee.Success
-                else sleep = 100 end
-            end
         end
 		Wait(sleep)
 	end
-end)]]
+end)

--- a/client/cl_loops.lua
+++ b/client/cl_loops.lua
@@ -1,4 +1,4 @@
-CreateThread(function()
+--[[CreateThread(function()
 	local vehicleWhitelist = {[0]=true,[1]=true,[2]=true,[3]=true,[4]=true,[5]=true,[6]=true,[7]=true,[8]=true,[9]=true,[10]=true,[11]=true,[12]=true,[17]=true,[19]=true,[20]=true}
 	local sleep = 100
 	while true do
@@ -54,4 +54,4 @@ CreateThread(function()
         end
 		Wait(sleep)
 	end
-end)
+end)]]

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,6 +12,7 @@ shared_scripts {
 client_scripts{
     'client/cl_main.lua',
     'client/cl_events.lua',
+    'client/cl_eventhandlers.lua',
     'client/cl_extraalerts.lua',
     'client/cl_commands.lua',
     'client/cl_loops.lua',


### PR DESCRIPTION
Removed the need for loops on the client for checking speed, gunshots and melee attacks.

Still in testing, currently gunshots definitely return alerts consistently, will post here as most alerts are confirmed.

