### PR TITLE
ps-dispatch configurable for both qbcore and esx

### DIFF
--- a/client/cl_commands.lua
+++ b/client/cl_commands.lua
@@ -69,6 +69,7 @@ RegisterCommand('911', function(source, args, rawCommand)
     end
 
     last911Used = timeNow
+    
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
         if not Functions[Config.Core].IsHandcuffed() then
@@ -114,6 +115,14 @@ RegisterCommand('911', function(source, args, rawCommand)
 end)
 
 RegisterCommand('911a', function(source, args, rawCommand)
+    local timeNow = GetCloudTimeAsInt()
+
+    if timeNow - last911Used <= Config.Cooldown911 then
+        return QBCore.Functions.Notify("Please wait before using it again", "error")
+    end
+
+    last911Used = timeNow
+
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
         if not Functions[Config.Core].IsHandcuffed() then
@@ -213,6 +222,14 @@ end)
 
 -- Regular 311 call that goes straight to the Police
 RegisterCommand('311a', function(source, args, rawCommand)
+    local timeNow = GetCloudTimeAsInt()
+
+    if timeNow - last311Used <= Config.Cooldown311 then
+        return QBCore.Functions.Notify("Please wait before using it again", "error")
+    end
+
+    last311Used = timeNow
+
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
         if not Functions[Config.Core].IsHandcuffed() then

--- a/client/cl_commands.lua
+++ b/client/cl_commands.lua
@@ -6,7 +6,7 @@ local phoneModel = Config.PhoneModel
 
 -- Item checks to return whether or not the client has a phone or not
 local function HasPhone()
-    return QBCore.Functions.HasItem("phone")
+    return Functions[Config.Core].HasPhone()
 end
 
 
@@ -63,22 +63,25 @@ end
 RegisterCommand('911', function(source, args, rawCommand)
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
-        if not exports['qb-policejob']:IsHandcuffed() then
+        if not Functions[Config.Core].IsHandcuffed() then
             if HasPhone() then
                 PhoneCallAnim()
                 Wait(math.random(3,8) * 1000)
                 playAnim = false
-                local plyData = QBCore.Functions.GetPlayerData()
+                local plyData = Functions[Config.Core].GetPlayerData()
                 local currentPos = GetEntityCoords(PlayerPedId())
                 local locationInfo = getStreetandZone(currentPos)
                 local gender = GetPedGender()
+
+                local firstname, lastname = Functions[Config.Core].GetName(plyData)
+
                 TriggerServerEvent("dispatch:server:notify",{
                     dispatchcodename = "911call", -- has to match the codes in sv_dispatchcodes.lua so that it generates the right blip
                     dispatchCode = "911",
                     firstStreet = locationInfo,
                     priority = 2, -- priority
-                    name = plyData.charinfo.firstname:sub(1,1):upper()..plyData.charinfo.firstname:sub(2).. " ".. plyData.charinfo.lastname:sub(1,1):upper()..plyData.charinfo.lastname:sub(2),
-                    number = plyData.charinfo.phone,
+                    name = firstname:sub(1,1):upper()..firstname:sub(2) .. " ".. lastname:sub(1,1):upper()..lastname:sub(2),
+                    number = Functions[Config.Core].GetPhoneNumber(plyData),
                     origin = {
                         x = currentPos.x,
                         y = currentPos.y,
@@ -92,25 +95,24 @@ RegisterCommand('911', function(source, args, rawCommand)
                 DeletePhone()
                 StopEntityAnim(PlayerPedId(), 'cellphone_text_to_call', "cellphone@", 3)
             else
-                QBCore.Functions.Notify("You can't call without a Phone!", "error", 4500)
+                Functions[Config.Core].Notify("You can't call without a Phone!", "error", 4500)
             end
         else
-            QBCore.Functions.Notify("You can't call police while handcuffed!", "error", 4500)
+            Functions[Config.Core].Notify("You can't call police while handcuffed!", "error", 4500)
         end
     else
-        QBCore.Functions.Notify('Please put a reason after the 911', "success")
+        Functions[Config.Core].Notify('Please put a reason after the 911', "success")
     end
 end)
 
 RegisterCommand('911a', function(source, args, rawCommand)
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
-        if not exports['qb-policejob']:IsHandcuffed() then
+        if not Functions[Config.Core].IsHandcuffed() then
             if HasPhone() then
                 PhoneCallAnim()
                 Wait(math.random(3,8) * 1000)
                 playAnim = false
-                local plyData = QBCore.Functions.GetPlayerData()
                 local currentPos = GetEntityCoords(PlayerPedId())
                 local locationInfo = getStreetandZone(currentPos)
                 local gender = GetPedGender()
@@ -134,13 +136,13 @@ RegisterCommand('911a', function(source, args, rawCommand)
                 DeletePhone()
                 StopEntityAnim(PlayerPedId(), 'cellphone_text_to_call', "cellphone@", 3)
             else
-                QBCore.Functions.Notify("You can't call without a Phone!", "error", 4500)
+                Functions[Config.Core].Notify("You can't call without a Phone!", "error", 4500)
             end
         else
-            QBCore.Functions.Notify("You can't call police while handcuffed!", "error", 4500)
+            Functions[Config.Core].Notify("You can't call police while handcuffed!", "error", 4500)
         end
     else
-        QBCore.Functions.Notify('Please put a reason after the 911', "success")
+        Functions[Config.Core].Notify('Please put a reason after the 911', "success")
     end
 end)
 
@@ -148,22 +150,26 @@ end)
 RegisterCommand('311', function(source, args, rawCommand)
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
-        if not exports['qb-policejob']:IsHandcuffed() then
+        if not Functions[Config.Core].IsHandcuffed() then
             if HasPhone() then
                 PhoneCallAnim()
                 Wait(math.random(3,8) * 1000)
                 playAnim = false
-                local plyData = QBCore.Functions.GetPlayerData()
+                local plyData = Functions[Config.Core].GetPlayerData()
+
                 local currentPos = GetEntityCoords(PlayerPedId())
                 local locationInfo = getStreetandZone(currentPos)
                 local gender = GetPedGender()
+
+                local firstname, lastname = Functions[Config.Core].GetName(plyData)
+
                 TriggerServerEvent("dispatch:server:notify",{
                     dispatchcodename = "311call", -- has to match the codes in sv_dispatchcodes.lua so that it generates the right blip
                     dispatchCode = "311",
                     firstStreet = locationInfo,
                     priority = 2, -- priority
-                    name = plyData.charinfo.firstname:sub(1,1):upper()..plyData.charinfo.firstname:sub(2).. " ".. plyData.charinfo.lastname:sub(1,1):upper()..plyData.charinfo.lastname:sub(2),
-                    number = plyData.charinfo.phone,
+                    name = firstname:sub(1,1):upper()..firstname:sub(2).. " ".. lastname:sub(1,1):upper()..lastname:sub(2),
+                    number = Functions[Config.Core].GetPhoneNumber(plyData),
                     origin = {
                         x = currentPos.x,
                         y = currentPos.y,
@@ -177,13 +183,13 @@ RegisterCommand('311', function(source, args, rawCommand)
                 DeletePhone()
                 StopEntityAnim(PlayerPedId(), 'cellphone_text_to_call', "cellphone@", 3)
             else
-                QBCore.Functions.Notify("You can't call without a Phone!", "error", 4500)
+                Functions[Config.Core].Notify("You can't call without a Phone!", "error", 4500)
             end
         else
-            QBCore.Functions.Notify("You can't call police while handcuffed!", "error", 4500)
+            Functions[Config.Core].Notify("You can't call police while handcuffed!", "error", 4500)
         end
     else
-        QBCore.Functions.Notify('Please put a reason after the 911', "success")
+        Functions[Config.Core].NotifyNotify('Please put a reason after the 911', "success")
     end
 end)
 
@@ -191,15 +197,15 @@ end)
 RegisterCommand('311a', function(source, args, rawCommand)
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
-        if not exports['qb-policejob']:IsHandcuffed() then
+        if not Functions[Config.Core].IsHandcuffed() then
             if HasPhone() then
                 PhoneCallAnim()
                 Wait(math.random(3,8) * 1000)
                 playAnim = false
-                local plyData = QBCore.Functions.GetPlayerData()
                 local currentPos = GetEntityCoords(PlayerPedId())
                 local locationInfo = getStreetandZone(currentPos)
                 local gender = GetPedGender()
+
                 TriggerServerEvent("dispatch:server:notify",{
                     dispatchcodename = "311call", -- has to match the codes in sv_dispatchcodes.lua so that it generates the right blip
                     dispatchCode = "311",
@@ -220,13 +226,13 @@ RegisterCommand('311a', function(source, args, rawCommand)
                 DeletePhone()
                 StopEntityAnim(PlayerPedId(), 'cellphone_text_to_call', "cellphone@", 3)
             else
-                QBCore.Functions.Notify("You can't call without a Phone!", "error", 4500)
+                Functions[Config.Core].Notify("You can't call without a Phone!", "error", 4500)
             end
         else
-            QBCore.Functions.Notify("You can't call police while handcuffed!", "error", 4500)
+            Functions[Config.Core].Notify("You can't call police while handcuffed!", "error", 4500)
         end
     else
-        QBCore.Functions.Notify('Please put a reason after the 911', "success")
+        Functions[Config.Core].Notify('Please put a reason after the 911', "success")
     end
 end)
 

--- a/client/cl_commands.lua
+++ b/client/cl_commands.lua
@@ -58,9 +58,17 @@ local function PhoneCallAnim()
     end)
 end
 
+local last911Used = 0
 
 -- Regular 911 call that goes straight to the Police
 RegisterCommand('911', function(source, args, rawCommand)
+    local timeNow = GetCloudTimeAsInt()
+
+    if timeNow - last911Used <= Config.Cooldown911 then
+        return QBCore.Functions.Notify("Please wait before using it again", "error")
+    end
+
+    last911Used = timeNow
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
         if not Functions[Config.Core].IsHandcuffed() then
@@ -146,8 +154,18 @@ RegisterCommand('911a', function(source, args, rawCommand)
     end
 end)
 
+local last311Used = 0
+
 -- Regular 311 call that goes straight to the Police
 RegisterCommand('311', function(source, args, rawCommand)
+    local timeNow = GetCloudTimeAsInt()
+
+    if timeNow - last311Used <= Config.Cooldown311 then
+        return QBCore.Functions.Notify("Please wait before using it again", "error")
+    end
+
+    last311Used = timeNow
+
     local msg = rawCommand:sub(5)
     if string.len(msg) > 0 then
         if not Functions[Config.Core].IsHandcuffed() then

--- a/client/cl_commands.lua
+++ b/client/cl_commands.lua
@@ -65,7 +65,7 @@ RegisterCommand('911', function(source, args, rawCommand)
     local timeNow = GetCloudTimeAsInt()
 
     if timeNow - last911Used <= Config.Cooldown911 then
-        return QBCore.Functions.Notify("Please wait before using it again", "error")
+        return Functions[Config.Core].Notify("Please wait before using it again", "error")
     end
 
     last911Used = timeNow
@@ -118,7 +118,7 @@ RegisterCommand('911a', function(source, args, rawCommand)
     local timeNow = GetCloudTimeAsInt()
 
     if timeNow - last911Used <= Config.Cooldown911 then
-        return QBCore.Functions.Notify("Please wait before using it again", "error")
+        return Functions[Config.Core].Notify("Please wait before using it again", "error")
     end
 
     last911Used = timeNow
@@ -170,7 +170,7 @@ RegisterCommand('311', function(source, args, rawCommand)
     local timeNow = GetCloudTimeAsInt()
 
     if timeNow - last311Used <= Config.Cooldown311 then
-        return QBCore.Functions.Notify("Please wait before using it again", "error")
+        return Functions[Config.Core].Notify("Please wait before using it again", "error")
     end
 
     last311Used = timeNow
@@ -225,7 +225,7 @@ RegisterCommand('311a', function(source, args, rawCommand)
     local timeNow = GetCloudTimeAsInt()
 
     if timeNow - last311Used <= Config.Cooldown311 then
-        return QBCore.Functions.Notify("Please wait before using it again", "error")
+        return Functions[Config.Core].Notify("Please wait before using it again", "error")
     end
 
     last311Used = timeNow

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -20,7 +20,7 @@ Functions.QBCore.Notify = function(...)
     Core.Functions.Notify(...)
 end
 Functions.QBCore.GetName = function(playerData)
-    return playerData.charinfo.firstname, playerData.charinfo.gender.lastname
+    return playerData.charinfo.firstname, playerData.charinfo.lastname
 end
 Functions.QBCore.HasPhone = function()
     return Core.Functions.HasItem("phone")
@@ -32,7 +32,7 @@ Functions.QBCore.GetCallSign = function(playerData)
     return playerData.metadata["callsign"]
 end
 Functions.QBCore.IsHandcuffed = function()
-    return exports['qb-police']:IsHandcuffed()
+    return exports['qb-policejob']:IsHandcuffed()
 end
 
 -- ESX
@@ -94,18 +94,18 @@ end)
 
 AddEventHandler('esx:setPlayerData', function(key, val, last)
     if GetInvokingResource() == 'es_extended' then
-        ESX.PlayerData[key] = val
+        Core.PlayerData[key] = val
     end
 end)
 
 RegisterNetEvent('esx:playerLoaded', function(xPlayer)
-    ESX.PlayerData = xPlayer
-    ESX.PlayerLoaded = true
+    Core.PlayerData = xPlayer
+    Core.PlayerLoaded = true
     isLoggedIn = true
 end)
 
 RegisterNetEvent('esx:onPlayerLogout', function()
-    ESX.PlayerLoaded = false
-    ESX.PlayerData = {}
+    Core.PlayerLoaded = false
+    Core.PlayerData = {}
     isLoggedIn = false
 end)

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -1,0 +1,111 @@
+Core = nil
+
+if Config.Core == "QBCore" then Core = exports['qb-core']:GetCoreObject()
+elseif Config.Core == "ESX" then Core = exports['es_extended']:getSharedObject() end
+
+Functions = {}
+
+-- QBCore
+Functions.QBCore = {}
+Functions.QBCore.GetPlayerData = function()
+    return Core.Functions.GetPlayerData()
+end
+Functions.QBCore.GetGender = function(playerData)
+    return playerData.charinfo.gender
+end
+Functions.QBCore.GetOnDuty = function(playerData)
+    return playerData.job.onduty
+end
+Functions.QBCore.Notify = function(...)
+    Core.Functions.Notify(...)
+end
+Functions.QBCore.GetName = function(playerData)
+    return playerData.charinfo.firstname, playerData.charinfo.gender.lastname
+end
+Functions.QBCore.HasPhone = function()
+    return Core.Functions.HasItem("phone")
+end
+Functions.QBCore.GetPhoneNumber = function(playerData)
+    return playerData.charinfo.phone
+end
+Functions.QBCore.GetCallSign = function(playerData)
+    return playerData.metadata["callsign"]
+end
+Functions.QBCore.IsHandcuffed = function()
+    return exports['qb-police']:IsHandcuffed()
+end
+
+-- ESX
+Functions.ESX = {}
+Functions.ESX.GetPlayerData = function()
+    return Core.PlayerData
+end
+Functions.ESX.GetGender = function(playerData)
+    return playerData.sex == "m" and 0 or 1
+end
+Functions.ESX.GetOnDuty = function()
+    return true
+end
+Functions.ESX.Notify = function(...)
+    Core.ShowNotification(...)
+end
+Functions.ESX.GetName = function(playerData)
+    return playerData.firstName, playerData.lastName
+end
+Functions.ESX.HasPhone = function()
+    return true
+end
+Functions.ESX.GetPhoneNumber = function()
+    return ''
+end
+Functions.ESX.GetCallSign = function()
+    return ''
+end
+Functions.ESX.IsHandcuffed = function()
+    return false
+end
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if GetCurrentResourceName() == resourceName then
+		isLoggedIn = true
+        PlayerData = Functions[Config.Core].GetPlayerData()
+        PlayerJob = PlayerData.job
+    end
+end)
+
+RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
+    isLoggedIn = true
+    PlayerData = Functions[Config.Core].GetPlayerData()
+    PlayerJob = PlayerData.job
+end)
+
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
+	PlayerData = {}
+    isLoggedIn = false
+    currentCallSign = ""
+    -- currentVehicle, inVehicle, currentlyArmed, currentWeapon = nil, false, false, `WEAPON_UNARMED`
+    -- removeHuntingZones()
+end)
+
+RegisterNetEvent("QBCore:Client:OnJobUpdate", function(JobInfo)
+    PlayerData = Functions[Config.Core].GetPlayerData()
+    PlayerJob = JobInfo
+end)
+
+AddEventHandler('esx:setPlayerData', function(key, val, last)
+    if GetInvokingResource() == 'es_extended' then
+        ESX.PlayerData[key] = val
+    end
+end)
+
+RegisterNetEvent('esx:playerLoaded', function(xPlayer)
+    ESX.PlayerData = xPlayer
+    ESX.PlayerLoaded = true
+    isLoggedIn = true
+end)
+
+RegisterNetEvent('esx:onPlayerLogout', function()
+    ESX.PlayerLoaded = false
+    ESX.PlayerData = {}
+    isLoggedIn = false
+end)

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -95,6 +95,7 @@ end)
 AddEventHandler('esx:setPlayerData', function(key, val, last)
     if GetInvokingResource() == 'es_extended' then
         Core.PlayerData[key] = val
+        PlayerJob = Core.PlayerData.job
     end
 end)
 
@@ -102,6 +103,7 @@ RegisterNetEvent('esx:playerLoaded', function(xPlayer)
     Core.PlayerData = xPlayer
     Core.PlayerLoaded = true
     isLoggedIn = true
+    PlayerJob = xPlayer.job
 end)
 
 RegisterNetEvent('esx:onPlayerLogout', function()

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -108,12 +108,14 @@ end)
 
 AddEventHandler('esx:setPlayerData', function(key, val, last)
     if GetInvokingResource() == 'es_extended' then
+        PlayerData[key] = val
         Core.PlayerData[key] = val
         PlayerJob = Core.PlayerData.job
     end
 end)
 
 RegisterNetEvent('esx:playerLoaded', function(xPlayer)
+    PlayerData = xPlayer
     Core.PlayerData = xPlayer
     Core.PlayerLoaded = true
     isLoggedIn = true
@@ -123,7 +125,14 @@ RegisterNetEvent('esx:playerLoaded', function(xPlayer)
 end)
 
 RegisterNetEvent('esx:onPlayerLogout', function()
+    PlayerData = {}
     Core.PlayerLoaded = false
     Core.PlayerData = {}
     isLoggedIn = false
+end)
+
+RegisterNetEvent('esx:setJob', function(job)
+    PlayerJob = job
+    PlayerData.job = job
+    Core.PlayerData.job = job
 end)

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -49,8 +49,12 @@ end
 Functions.ESX.Notify = function(...)
     Core.ShowNotification(...)
 end
+
+local esxFirstName = nil
+local esxLastName = nil
+
 Functions.ESX.GetName = function(playerData)
-    return playerData.firstName, playerData.lastName
+    return (playerData.firstName or esxFirstName or ""), (playerData.lastName or esxLastName or "")
 end
 Functions.ESX.HasPhone = function()
     return true
@@ -64,12 +68,22 @@ end
 Functions.ESX.IsHandcuffed = function()
     return false
 end
+Functions.ESX.LoadPlayerName = function()
+    Core.TriggerServerCallback('ps-dispatch:server:esx:getPlayerName', function(firstName, lastName)
+        esxFirstName = firstName
+        esxLastName = lastName
+    end)
+end
 
 AddEventHandler('onResourceStart', function(resourceName)
     if GetCurrentResourceName() == resourceName then
         isLoggedIn = true
         PlayerData = Functions[Config.Core].GetPlayerData()
         PlayerJob = PlayerData.job
+
+        if Config.Core == "ESX" then
+            Functions.ESX.LoadPlayerName()
+        end
     end
 end)
 
@@ -104,6 +118,8 @@ RegisterNetEvent('esx:playerLoaded', function(xPlayer)
     Core.PlayerLoaded = true
     isLoggedIn = true
     PlayerJob = xPlayer.job
+
+    Functions.ESX.LoadPlayerName()
 end)
 
 RegisterNetEvent('esx:onPlayerLogout', function()

--- a/client/cl_core.lua
+++ b/client/cl_core.lua
@@ -67,7 +67,7 @@ end
 
 AddEventHandler('onResourceStart', function(resourceName)
     if GetCurrentResourceName() == resourceName then
-		isLoggedIn = true
+        isLoggedIn = true
         PlayerData = Functions[Config.Core].GetPlayerData()
         PlayerJob = PlayerData.job
     end
@@ -80,7 +80,7 @@ RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-	PlayerData = {}
+    PlayerData = {}
     isLoggedIn = false
     currentCallSign = ""
     -- currentVehicle, inVehicle, currentlyArmed, currentWeapon = nil, false, false, `WEAPON_UNARMED`

--- a/client/cl_events.lua
+++ b/client/cl_events.lua
@@ -525,10 +525,10 @@ end
 exports('CarJacking', CarJacking)
 
 local function OfficerDown()
-    local plyData = QBCore.Functions.GetPlayerData()
+    local plyData = Functions[Config.Core].GetPlayerData()
     local currentPos = GetEntityCoords(PlayerPedId())
     local locationInfo = getStreetandZone(currentPos)
-    local callsign = QBCore.Functions.GetPlayerData().metadata["callsign"]
+    local callsign = Functions[Config.Core].GetCallSign(plyData)
     TriggerServerEvent("dispatch:server:notify", {
         dispatchcodename = "officerdown", -- has to match the codes in sv_dispatchcodes.lua so that it generates the right blip
         dispatchCode = "10-99",
@@ -557,10 +557,10 @@ RegisterNetEvent("ps-dispatch:client:officerdown", function ()
 end)
 
 local function EmsDown()
-    local plyData = QBCore.Functions.GetPlayerData()
+    local plyData = Functions[Config.Core].GetPlayerData()
     local currentPos = GetEntityCoords(PlayerPedId())
     local locationInfo = getStreetandZone(currentPos)
-    local callsign = QBCore.Functions.GetPlayerData().metadata["callsign"]
+    local callsign = Functions[Config.Core].GetCallSign(plyData)
     TriggerServerEvent("dispatch:server:notify", {
         dispatchcodename = "emsdown", -- has to match the codes in sv_dispatchcodes.lua so that it generates the right blip
         dispatchCode = "10-99",

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -162,7 +162,8 @@ end
 
 local function CheckOnDuty()
 	if Config.OnDutyOnly then
-		return Functions[Config.Core].GetOnDuty(PlayerData)
+		local playerData = Functions[Config.Core].GetPlayerData()
+		return Functions[Config.Core].GetOnDuty(playerData)
 	end
 	return true
 end

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -309,8 +309,3 @@ RegisterNetEvent("ps-dispatch:client:clearAllBlips", function()
 	end
 	Functions[Config.Core].Notify('All dispatch blips cleared', "success")
 end)
-
-
-RegisterCommand("test", function()
-	exports['ps-dispatch']:PrisonBreak()
-end)

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -1,42 +1,13 @@
 PlayerData = {}
 PlayerJob = {}
 isLoggedIn = true
-QBCore = exports['qb-core']:GetCoreObject()
+
 local blips = {}
 
 -- Debugging and testing dispatch alerts - Uncomment to use. 
 --RegisterCommand('testdispatch',function ()
 --    TriggerEvent('')
 --end)
-
--- core related
-
-AddEventHandler('onResourceStart', function(resourceName)
-    if GetCurrentResourceName() == resourceName then
-		isLoggedIn = true
-        PlayerData = QBCore.Functions.GetPlayerData()
-        PlayerJob = QBCore.Functions.GetPlayerData().job
-    end
-end)
-
-RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
-    isLoggedIn = true
-    PlayerData = QBCore.Functions.GetPlayerData()
-    PlayerJob = QBCore.Functions.GetPlayerData().job
-end)
-
-RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-	PlayerData = {}
-    isLoggedIn = false
-    currentCallSign = ""
-    -- currentVehicle, inVehicle, currentlyArmed, currentWeapon = nil, false, false, `WEAPON_UNARMED`
-    -- removeHuntingZones()
-end)
-
-RegisterNetEvent("QBCore:Client:OnJobUpdate", function(JobInfo)
-    PlayerData = QBCore.Functions.GetPlayerData()
-    PlayerJob = JobInfo
-end)
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -159,7 +130,7 @@ end
 
 function GetPedGender()
     local gender = "Male"
-    if QBCore.Functions.GetPlayerData().charinfo.gender == 1 then gender = "Female" end
+    if Functions[Config.Core].GetGender(PlayerData) == 1 then gender = "Female" end
     return gender
 end
 
@@ -191,7 +162,7 @@ end
 
 local function CheckOnDuty()
 	if Config.OnDutyOnly then
-		return QBCore.Functions.GetPlayerData().job.onduty
+		return Functions[Config.Core].GetOnDuty(PlayerData)
 	end
 	return true
 end
@@ -200,22 +171,23 @@ end
 
 local disableNotis, disableNotifSounds = false, false
 
+-- @TODO notify
 RegisterNetEvent('dispatch:manageNotifs', function(sentSetting)
     local wantedSetting = tostring(sentSetting)
     if wantedSetting == "on" then
         disableNotis = false
         disableNotifSounds = false
-        QBCore.Functions.Notify("Dispatch enabled", "success")
+        Functions[Config.Core].Notify("Dispatch enabled", "success")
     elseif wantedSetting == "off" then
         disableNotis = true
         disableNotifSounds = true
-        QBCore.Functions.Notify("Dispatch disabled", "success")
+        Functions[Config.Core].Notify("Dispatch disabled", "success")
     elseif wantedSetting == "mute" then
         disableNotis = false
         disableNotifSounds = true
-        QBCore.Functions.Notify("Dispatch muted", "success")
+        Functions[Config.Core].Notify("Dispatch muted", "success")
     else
-        QBCore.Functions.Notify('Please choose to have dispatch as "on", "off" or "mute".', "success")
+        Functions[Config.Core].Notify('Please choose to have dispatch as "on", "off" or "mute".', "success")
 
     end
 end)
@@ -335,5 +307,10 @@ RegisterNetEvent("ps-dispatch:client:clearAllBlips", function()
 	for k, v in pairs(blips) do
 		RemoveBlip(v)
 	end
-	QBCore.Functions.Notify('All dispatch blips cleared', "success")
+	Functions[Config.Core].Notify('All dispatch blips cleared', "success")
+end)
+
+
+RegisterCommand("test", function()
+	exports['ps-dispatch']:PrisonBreak()
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 
-Config.Core = "ESX"
+Config.Core = "QBCore"
 
 Config.Enable = {}
 Config.Timer = {}

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,10 @@ Config = {}
 
 Config.Core = "QBCore"
 
+Config.RecentCallsSize = 50
+Config.Cooldown911 = 60
+Config.Cooldown311 = 60
+
 Config.Enable = {}
 Config.Timer = {}
 

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,7 @@
 Config = {}
 
+Config.Core = "ESX"
+
 Config.Enable = {}
 Config.Timer = {}
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,8 +4,6 @@ game 'gta5'
 version '0.0'
 description 'https://github.com/Project-Sloth/ps-dispatch'
 
-client_script '@es_extended/imports.lua'
-
 shared_scripts {
     'config.lua',
     'locales/locales.lua',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,12 +4,15 @@ game 'gta5'
 version '0.0'
 description 'https://github.com/Project-Sloth/ps-dispatch'
 
+client_script '@es_extended/imports.lua'
+
 shared_scripts {
     'config.lua',
     'locales/locales.lua',
 }
 
 client_scripts{
+    'client/cl_core.lua',
     'client/cl_main.lua',
     'client/cl_events.lua',
     'client/cl_eventhandlers.lua',
@@ -18,6 +21,7 @@ client_scripts{
     'client/cl_loops.lua',
 } 
 server_script {
+    'server/sv_core.lua',
     'server/sv_dispatchcodes.lua',
     'server/sv_main.lua'
 }

--- a/server/sv_core.lua
+++ b/server/sv_core.lua
@@ -35,3 +35,29 @@ end
 Functions.ESX.RegisterCommand = function(name, help, args, argsReq, cb)
     Core.RegisterCommand(name, 'user', cb, argsReq, {help = help, arguments = args})
 end
+
+if Config.Core == "ESX" then
+    Core.RegisterServerCallback('ps-dispatch:server:esx:getPlayerName', function(src, cb)
+        local player = Functions.ESX.GetPlayer(src)
+        if not player then return cb('', '') end
+
+        local rawName = Functions.ESX.GetName(player) or ""
+        local name = rawName:gmatch("%S+")
+        local firstname = nil
+        local lastname = nil
+
+        local i = 0
+        for token in name do
+            if i == 0 then firstname = token
+            elseif i == 1 then lastname = token
+            else break end
+
+            i = i + 1
+        end
+        
+        firstname = firstname or ""
+        lastname = lastname or ""
+
+        cb(firstname, lastname)
+    end)
+end

--- a/server/sv_core.lua
+++ b/server/sv_core.lua
@@ -1,0 +1,37 @@
+Core = nil
+
+if Config.Core == "QBCore" then Core = exports['qb-core']:GetCoreObject()
+elseif Config.Core == "ESX" then Core = exports['es_extended']:getSharedObject() end
+
+Functions = {}
+
+Functions.QBCore = {}
+Functions.QBCore.GetPlayer = function(src)
+    return Core.Functions.GetPlayer(src)
+end
+Functions.QBCore.GetName = function(player)
+    return player.PlayerData.charinfo.firstname .. " " .. player.PlayerData.charinfo.lastname
+end
+Functions.QBCore.GetJob = function(player)
+    return player.PlayerData.job
+end
+Functions.QBCore.RegisterCommand = function(name, help, args, argsReq, cb)
+    Core.Commands.Add(name, help, args, argsReq, function(source, ...)
+        local player = Core.Functions.GetPlayer(source)
+        cb(player, ...)
+    end)
+end
+
+Functions.ESX = {}
+Functions.ESX.GetPlayer = function(src)
+    return Core.GetPlayerFromId(src)
+end
+Functions.ESX.GetName = function(player)
+    return player.getName()
+end
+Functions.ESX.GetJob = function(player)
+    return player.getJob()
+end
+Functions.ESX.RegisterCommand = function(name, help, args, argsReq, cb)
+    Core.RegisterCommand(name, 'user', cb, argsReq, {help = help, arguments = args})
+end

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -1,4 +1,5 @@
 local calls = {}
+local recentCalls = {}
 
 function _U(entry)
 	return Locales[Config.Locale][entry] 
@@ -31,6 +32,14 @@ RegisterServerEvent("dispatch:server:notify", function(data)
     calls[newId]['responses'] = {}
     calls[newId]['time'] = os.time() * 1000
 
+    local recentSize = #recentCalls
+
+    if recentSize >= Config.RecentCallsSize then
+        table.remove(recentCalls, 1)
+    end
+
+    table.insert(recentCalls, calls[newId])
+
 	TriggerClientEvent('dispatch:clNotify', -1, data, newId, source)
     if not data.alert then 
         TriggerClientEvent("ps-dispatch:client:AddCallBlip", -1, data.origin, dispatchCodes[data.dispatchcodename], newId)
@@ -38,6 +47,9 @@ RegisterServerEvent("dispatch:server:notify", function(data)
         TriggerClientEvent("ps-dispatch:client:AddCallBlip", -1, data.origin, data.alert, newId)
     end
 end)
+
+function GetRecentDispatchCalls() return recentCalls end
+exports('GetRecentDispatchCalls', GetRecentDispatchCalls) -- 
 
 function GetDispatchCalls() return calls end
 exports('GetDispatchCalls', GetDispatchCalls) -- 


### PR DESCRIPTION
Requires only change in `Config.Core` variable i.e. `QBCore` or `ESX` in `config.lua`
Fixes a bug in remove unit causing errors