### PR TITLE
Fix typo, fix first responder check, moved default hunting zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Do not create issues on GitHub if you need help. Issues are for bug reporting an
 
 - exports['ps-dispatch']:Fight()
 
-- exports['ps-dispatch']:InjuriedPerson()
+- exports['ps-dispatch']:InjuredPerson()
 
 - exports['ps-dispatch']:DeceasedPerson()
 

--- a/client/cl_eventhandlers.lua
+++ b/client/cl_eventhandlers.lua
@@ -190,7 +190,7 @@ AddEventHandler('gameEventTriggered', function(name, args)
     -- If the victim isn't dead, don't trigger the event as well
     if not isDead then Config.Timer['PlayerDowned'] = Config.PlayerDowned.Fail return end
     -- Check if the player is and EMS, trigger the correct down alerts
-    if not Config.AuthorizedJobs.FirstResponder.Check() then exports['ps-dispatch']:InjuriedPerson() end
+    if not Config.AuthorizedJobs.FirstResponder.Check() then exports['ps-dispatch']:InjuredPerson() end
     if Config.AuthorizedJobs.LEO.Check() then exports['ps-dispatch']:OfficerDown() end
     if Config.AuthorizedJobs.EMS.Check() then exports['ps-dispatch']:EmsDown() end
     Config.Timer['PlayerDowned'] = Config.PlayerDowned.Success

--- a/client/cl_events.lua
+++ b/client/cl_events.lua
@@ -199,7 +199,7 @@ end
 
 exports('Fight', Fight)
 
-local function InjuriedPerson()
+local function InjuredPerson()
     local currentPos = GetEntityCoords(PlayerPedId())
     local locationInfo = getStreetandZone(currentPos)
     local gender = GetPedGender()
@@ -223,7 +223,7 @@ local function InjuriedPerson()
     })
 end
 
-exports('InjuriedPerson', InjuriedPerson)
+exports('InjuredPerson', InjuredPerson)
 
 local function DeceasedPerson()
     local currentPos = GetEntityCoords(PlayerPedId())

--- a/config.lua
+++ b/config.lua
@@ -38,7 +38,7 @@ Config.MaxOffset = 120
 -- Locations for the Hunting Zones and No Dispatch Zones( Label: Name of Blip // Radius: Radius of the Alert and Blip)
 Config.Locations = {
     ["hunting"] = {
-        [1] = {label = "Hunting Zone", radius = 250.0, coords = vector3(-1339.05, -3044.38, 13.94)},
+        [1] = {label = "Hunting Zone", radius = 250.0, coords = vector3(-1423.96, 4402.2, 47.0)},
     },
     ["NoDispatch"] = {
         [1] = {label = "Ammunation 1", coords = vector3(13.53, -1097.92, 29.8), length = 14.0, width = 5.0, heading = 70, minZ = 28.8, maxZ = 32.8},

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -87,11 +87,11 @@ end)
 
 
 RegisterCommand('togglealerts', function(source, args, user)
-	local src = source
+    local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-	if Config.AuthorizedJobs.FirstResponder.Check(Player.PlayerData) then
-		TriggerClientEvent('dispatch:manageNotifs', src, args[1])
-	end
+    if Config.AuthorizedJobs.FirstResponder.Check(Player.PlayerData) then
+        TriggerClientEvent('dispatch:manageNotifs', src, args[1])
+    end
 end)
 
 -- Explosion Handler

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -75,7 +75,7 @@ end)
 AddEventHandler("dispatch:removeUnit", function(callid, player, cb)
     if calls[callid] then
         if #calls[callid]['units'] > 0 then
-            for i=1, #calls[callid]['units'] do
+            for i = 1, #calls[callid]['units'] do
                 if calls[callid]['units'][i]['cid'] == player.cid then
                     calls[callid]['units'][i] = nil
                 end

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -87,9 +87,10 @@ end)
 
 
 RegisterCommand('togglealerts', function(source, args, user)
-	local source = source
-	if IsDispatchJob then
-		TriggerClientEvent('dispatch:manageNotifs', source, args[1])
+	local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+	if Config.AuthorizedJobs.FirstResponder.Check(Player.PlayerData) then
+		TriggerClientEvent('dispatch:manageNotifs', src, args[1])
 	end
 end)
 


### PR DESCRIPTION
- Fixed typo from `InjuriedPerson` to `InjuredPerson`
- Moved default hunting zone from middle of LSIA to in the county by the river
  
![image](https://github.com/Project-Sloth/ps-dispatch/assets/18689469/56285995-f4b9-467d-b129-fe31e3c15cb9)

- Fixed the first responder check in `togglealerts`
   - Fixes https://github.com/Project-Sloth/ps-dispatch/issues/140