### PR TITLE
Update main.lua

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -26,11 +26,12 @@ end)
 
 RegisterServerEvent('ps-dispatch:server:detach', function(id, player)
     if not calls[id] then return end
-    if not #calls[id]['units'] then return end
-
-    for i=1, #calls[id]['units'] do
-        if calls[id]['units'][i]['citizenid'] == player.citizenid then
-            calls[id]['units'][i] = nil
+    if not calls[id]['units'] then return end
+    if (#calls[id]['units'] or 0) > 0 then
+        for i = #calls[id]['units'], 1, -1 do
+            if calls[id]['units'][i]['citizenid'] == player.citizenid then
+                table.remove(calls[id]['units'], i)
+            end
         end
     end
 end)


### PR DESCRIPTION
Proper reverse iteration of calls[id]['units'] and use of table.remove to prevent 'gaps' in numerically indexed table; 'gaps' will otherwise break subsequent "for i=" loop attempts regardless of direction.

(apologies if this pull is to the wrong branch, but it should be applicable regardless)