### PR TITLE
Dispatch hotkey and setwaypoint cooldown/notify

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,10 +14,12 @@
   "no_calls": "No Calls Found.",
   "alerts": "Alerts ",
   "blips_cleared": "Blips Cleared",
+  "alerts_refreshed": "Alerts Refreshed",
   "enabled": "Enabled",
   "disabled": "Disabled",
   "muted": "Muted",
   "unmuted": "Unmuted",
+  "waypoint_set": "Waypoint set.",
 
   "caller_local": "Local",
   "call_from": "Call from ",

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -3,6 +3,7 @@ Config = Config or {}
 Config.Debug = false -- Enables debug and send alerts when leo break the law.
 
 Config.RespondKeybind = 'E'
+Config.OpenDispatchMenu = 'O'
 Config.AlertTime = 5     -- How many seconds you want the alert to stay on screen
 
 Config.OnDutyOnly = true -- Set true if only on duty players can see the alert


### PR DESCRIPTION
- openMenu function for lib.addkeybind
- waypoint Cooldown (Cooldown is Config.AlertTime) with Notify
- added Config.OpenDispatchMenu ( Default is O )
- changed lib notify positions to top/middle only not top/middle and top/right
- added 2 new locales ( waypoint_set and alerts_refreshed )