### PR TITLE
Cut Down Array Size for Performance

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -52,12 +52,12 @@ end
 local function openMenu()
     if not isJobValid(PlayerData.job.type) then return end
 
-    local data = lib.callback.await('ps-dispatch:callback:getCalls', false)
-    if #data == 0 then
+    local calls = lib.callback.await('ps-dispatch:callback:getCalls', false)
+    if #calls == 0 then
         lib.notify({ description = locale('no_calls'), position = 'top', type = 'error' })
     else
+        SendNUIMessage({ action = 'setDispatchs', data = calls, })
         toggleUI(true)
-        SendNUIMessage({ action = 'setDispatchs', data = data, })
     end
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -24,21 +24,30 @@ RegisterServerEvent('ps-dispatch:server:notify', function(data)
 end)
 
 RegisterServerEvent('ps-dispatch:server:attach', function(id, player)
-    for i=1, #calls[id]['units'] do
-        if calls[id]['units'][i]['citizenid'] == player.citizenid then return end
+    for i=1, #calls do
+        if calls[i]['id'] == id then
+            for j = 1, #calls[i]['units'] do
+                if calls[i]['units'][j]['citizenid'] == player.citizenid then
+                    return
+                end
+            end
+            calls[i]['units'][#calls[i]['units'] + 1] = player
+            return
+        end
     end
-
-    calls[id]['units'][#calls[id]['units'] + 1] = player
 end)
 
 RegisterServerEvent('ps-dispatch:server:detach', function(id, player)
-    if not calls[id] then return end
-    if not calls[id]['units'] then return end
-    if (#calls[id]['units'] or 0) > 0 then
-        for i = #calls[id]['units'], 1, -1 do
-            if calls[id]['units'][i]['citizenid'] == player.citizenid then
-                table.remove(calls[id]['units'], i)
+    for i = #calls, 1, -1 do
+        if calls[i]['id'] == id then
+            if calls[i]['units'] and (#calls[i]['units'] or 0) > 0 then
+                for j = #calls[i]['units'], 1, -1 do
+                    if calls[i]['units'][j]['citizenid'] == player.citizenid then
+                        table.remove(calls[i]['units'], j)
+                    end
+                end
             end
+            return
         end
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,5 @@
 local calls = {}
+local callCount = 0
 
 -- Functions
 exports('GetDispatchCalls', function()
@@ -7,10 +8,16 @@ end)
 
 -- Events
 RegisterServerEvent('ps-dispatch:server:notify', function(data)
-    data.id = #calls + 1
+    callCount = callCount + 1
+    data.id = callCount
     data.time = os.time() * 1000
     data.units = {}
     data.responses = {}
+
+    if #calls >= Config.MaxCallList then
+        table.remove(calls, 1)
+    end
+
     calls[#calls + 1] = data
 
     TriggerClientEvent('ps-dispatch:client:notify', -1, data)


### PR DESCRIPTION
The current performance issue we have is where the array just grows with info and gets to a point where the size of the array gets pushed no matter what the Config.MaxCallList is, So an array filled with 200 calls that gets pushed to the client and then sliced in the UI which is causing the dispatch lag and most likely the MDT lag.

This is a small change that keeps the array size to match the Config.MaxCallList which fixes the performance issues.

// WIP