### PR TITLE
PlayerData Performance Improvement

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -17,8 +17,23 @@ local function toggleUI(bool)
 end
 
 local function setupDispatch()
-    PlayerData = QBCore.Functions.GetPlayerData()
+    local playerInfo = QBCore.Functions.GetPlayerData()
     local locales = lib.getLocales()
+    PlayerData = {
+        charinfo = {
+            firstname = playerInfo.charinfo.firstname,
+            lastname = playerInfo.charinfo.lastname
+        },
+        metadata = {
+            callsign = playerInfo.metadata.callsign
+        },
+        citizenid = playerInfo.citizenid,
+        job = {
+            type = playerInfo.job.type,
+            name = playerInfo.job.name,
+            label = playerInfo.job.label
+        },
+    }
 
     Wait(1000)
 

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -21,9 +21,8 @@ function GetIsHandcuffed()
 end
 
 function IsOnDuty()
-    PlayerData = QBCore.Functions.GetPlayerData()
     if Config.OnDutyOnly then
-        if PlayerData.job.onduty then
+        if QBCore.Functions.GetPlayerData().job.onduty then
             return true
         else
             return false


### PR DESCRIPTION
This is in conjunction with the last PR for performance improvements, This is a PR to change the amount of info we grab from the Player's Data, Instead of grabbing all their data which is quite large, We only grab what we need / use, This helps by only sending that table to the UI and not an array size of 500 entries, I have tested this on my live and it has an instant performance increase when you have people attached to calls and trying to open the MDT / Dispatch

There is no changes needed to ps-mdt for this as we provide it with all the info as well from this table.