### PR TITLE
311 / 911 Fix & No Phone Notify

### DIFF
--- a/client/alerts.lua
+++ b/client/alerts.lua
@@ -545,7 +545,7 @@ local function CustomAlert(data)
 end
 exports('CustomAlert', CustomAlert)
 
-local function PhoneCall(message, anonymous, job)
+local function PhoneCall(message, anonymous, job, type)
     local coords = GetEntityCoords(cache.ped)
 
     if IsCallAllowed(message) then
@@ -553,8 +553,8 @@ local function PhoneCall(message, anonymous, job)
 
         local dispatchData = {
             message = anonymous and locale('anon_call') or locale('call'),
-            codeName = '911call',
-            code = '911',
+            codeName = type == '311' and '311call' or '911call',
+            code = type,
             icon = 'fas fa-phone',
             priority = 2,
             coords = coords,
@@ -575,7 +575,7 @@ end
 RegisterNetEvent('ps-dispatch:client:sendEmergencyMsg', function(data, type, anonymous)
     local jobs = { ['911'] = { 'leo' }, ['311'] = { 'ems' } }
 
-    PhoneCall(data, anonymous, jobs[type])
+    PhoneCall(data, anonymous, jobs[type], type)
 end)
 
 

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -142,7 +142,7 @@ function IsCallAllowed(message)
 
     if msgLength == 0 then return false end
     if GetIsHandcuffed() then return false end
-    if Config.PhoneRequired and not HasPhone() then return false end
+    if Config.PhoneRequired and not HasPhone() then QBCore.Functions.Notify('You need a communications device for this.', 'error', 5000) return false end
 
     return true
 end


### PR DESCRIPTION
Small Fix for 311 / 911 Calls, There is now a difference, before it was only dispatching 911 calls no matter type.
I added a notification if you don't you have a phone.