### PR TITLE
Re-added Camera ID in dispatch notifications

### DIFF
--- a/ui/src/components/Main.svelte
+++ b/ui/src/components/Main.svelte
@@ -39,6 +39,7 @@
       { icon: 'fas fa-user', label: 'Name', value: dispatch.data.name },
       { icon: 'fas fa-phone', label: 'Number', value: dispatch.data.number },
       { icon: 'fas fa-comment', label: 'Information', value: dispatch.data.information },
+      { icon: 'fas fa-video', label: 'Camera ID', value: dispatch.data.camId },      
       { icon: 'fas fa-map-location-dot', label: 'Street', value: dispatch.data.street },
       { icon: 'fas fa-user', label: 'Gender', value: dispatch.data.gender },
       { icon: 'fas fa-gun', label: 'Automatic Gun Fire', value: dispatch.data.automaticGunFire },

--- a/ui/src/components/Menu.svelte
+++ b/ui/src/components/Menu.svelte
@@ -64,6 +64,7 @@
       { icon: 'fas fa-comment', label: 'Information', value: dispatch.information },
       { icon: 'fas fa-map-location-dot', label: 'Street', value: dispatch.street },
       { icon: 'fas fa-user', label: 'Gender', value: dispatch.gender },
+      { icon: 'fas fa-video', label: 'Camera ID', value: dispatch.camId },
       { icon: 'fas fa-gun', label: 'Automatic Gun Fire', value: dispatch.automaticGunFire },
       { icon: 'fas fa-gun', label: 'Weapon', value: dispatch.weapon },
       { icon: 'fas fa-car', label: 'Vehicle', value: dispatch.vehicle },


### PR DESCRIPTION
The svelte files that compile the UI didn't include the Cam ID as it did in Version 1.0 of the script.

This needs to be re-compiled.