### PR TITLE
Fix(dispatch): Do not send the same event multiple times

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -14,6 +14,12 @@ RegisterServerEvent('ps-dispatch:server:notify', function(data)
     data.units = {}
     data.responses = {}
 
+    if #calls > 0 then
+        if calls[#calls] == data then
+            return
+        end
+    end
+        
     if #calls >= Config.MaxCallList then
         table.remove(calls, 1)
     end


### PR DESCRIPTION
This pull request addresses the issue of redundant event notifications being sent. The added code ensures that the same event is not sent multiple times by checking the last entry in the event log (calls) against the new event data (data). If the last entry matches the new data, the code detects this scenario and prevents the duplicate event from being sent. This enhancement improves the efficiency of event handling and prevents unnecessary notifications from being dispatched.

Changes Made:

Added a conditional check to prevent duplicate event notifications.
