### PR TITLE
Restrict Dispatch Functions to On-Duty Personnel and Add Exemptions for Aircrafts

### DIFF
--- a/client/eventhandlers.lua
+++ b/client/eventhandlers.lua
@@ -42,7 +42,7 @@ AddEventHandler('CEventGunShot', function(witnesses, ped)
     if IsPedCurrentWeaponSilenced(cache.ped) then return end
     if inNoDispatchZone then return end
     if BlacklistedWeapon(cache.ped) then return end
-        
+
     WaitTimer('Shooting', function()
         if cache.ped ~= ped then return end
 
@@ -128,6 +128,11 @@ local SpeedingEvents = {
     'CEventShockingInDangerousVehicle'
 }
 
+local exemptVehicleClass = {
+    [15] = true, -- Helicopters
+    [16] = true, -- Planes
+}
+
 local SpeedTrigger = 0
 for i = 1, #SpeedingEvents do
     local event = SpeedingEvents[i]
@@ -144,7 +149,10 @@ for i = 1, #SpeedingEvents do
                     return
                 end
             end
-            
+
+            local vehicleClass = GetVehicleClass(cache.vehicle)
+            if exemptVehicleClass[vehicleClass] then return end
+
             if GetEntitySpeed(cache.vehicle) * 3.6 < (80 + math.random(0, 20)) then return end
 
             if cache.ped ~= GetPedInVehicleSeat(cache.vehicle, -1) then return end

--- a/client/main.lua
+++ b/client/main.lua
@@ -26,7 +26,7 @@ local function removeZones()
     for i = 1, #nodispatchZones do
         nodispatchZones[i]:remove()
     end
-    -- Hunting Blips --    
+    -- Hunting Blips --
     for i = 1, #huntingBlips do
         RemoveBlip(huntingBlips[i])
     end
@@ -151,6 +151,7 @@ end
 
 local function setWaypoint()
     if not isJobValid(PlayerData.job.type) then return end
+    if not IsOnDuty() then return end
 
     local data = lib.callback.await('ps-dispatch:callback:getLatestDispatch', false)
 
@@ -158,7 +159,7 @@ local function setWaypoint()
 
     if data.alertTime == nil then data.alertTime = Config.AlertTime end
     local timer = data.alertTime * 1000
-    
+
     if not waypointCooldown and lib.table.contains(data.jobs, PlayerData.job.type) then
         SetNewWaypoint(data.coords.x, data.coords.y)
         TriggerServerEvent('ps-dispatch:server:attach', data.id, PlayerData)
@@ -262,7 +263,7 @@ local OpenDispatchMenu = lib.addKeybind({
 RegisterNetEvent('ps-dispatch:client:notify', function(data, source)
     if data.alertTime == nil then data.alertTime = Config.AlertTime end
     local timer = data.alertTime * 1000
-    
+
     if alertsDisabled then return end
     if not isJobValid(data.jobs) then return end
     if not IsOnDuty() then return end
@@ -301,6 +302,7 @@ end)
 
 RegisterNetEvent('ps-dispatch:client:openMenu', function(data)
     if not isJobValid(PlayerData.job.type) then return end
+    if not IsOnDuty() then return end
 
     if #data == 0 then
         lib.notify({ description = locale('no_calls'), position = 'top', type = 'error' })


### PR DESCRIPTION
- Since the player can't see dispatch notifications unless they are on duty. Opening the dispatch menu and setting waypoints should be disabled as well.

- Made an exemption class table for plane and helicopter vehicle classes. This allows these vehicle classes to fly over roads without triggering the reckless driving call.