### PR TITLE
Fix two major issues with trying to use the CustomAlert() function

### DIFF
--- a/client/alerts.lua
+++ b/client/alerts.lua
@@ -32,8 +32,8 @@ local function CustomAlert(data)
             length = data.length or 2, -- How long it stays on the map
             sound = data.sound or "Lose_1st", -- Alert sound
             sound2 = data.sound2 or "GTAO_FM_Events_Soundset", -- Alert sound
-            offset = data.offset or "false", -- Blip / radius offset
-            flash = data.flash or "false" -- Blip flash
+            offset = data.offset or false, -- Blip / radius offset
+            flash = data.flash or false -- Blip flash
         },
         jobs = { 'leo' },
     }

--- a/client/main.lua
+++ b/client/main.lua
@@ -277,7 +277,7 @@ RegisterNetEvent('ps-dispatch:client:notify', function(data, source)
         }
     })
 
-    addBlip(data, Config.Blips[data.codeName] or data)
+    addBlip(data, Config.Blips[data.codeName] or data.alert)
 
     RespondToDispatch:disable(false)
     OpenDispatchMenu:disable(true)


### PR DESCRIPTION
Im working on a robbery creator script an spent a long time trying to figure out why the CustomAlert() function was not working with the data that i was trying to send through and then realized that the dispatch script had these two major mistakes that were causing all the weird functionality. I still dont know why camID doesnt work though. 