### PR TITLE
Added a check if the JOB is NIL

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -125,6 +125,7 @@ end
 ---@param data string | table -- The player job or an array of jobs to check against
 ---@return boolean -- Returns true if the job is valid
 local function isJobValid(data)
+    if PlayerData.job == nil then return false end
     local jobType = PlayerData.job.type
     local jobName = PlayerData.job.name
 


### PR DESCRIPTION
When cops receive a notification and there is someone that is still in the character screen, it throws a nil job error since they didn't load their character yet.

![image](https://github.com/user-attachments/assets/19357ec6-626c-4563-9bc1-82b177fca799)
