### PR TITLE
Update setWaypoint function to include a timeout check to make sure you can't press 'E' after a notifications time has cleared.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -153,14 +153,17 @@ end
 local function setWaypoint()
     if not isJobValid(PlayerData.job.type) then return end
     if not IsOnDuty() then return end
-
+    
     local data = lib.callback.await('ps-dispatch:callback:getLatestDispatch', false)
-
+    
     if not data then return end
-
+    
     if data.alertTime == nil then data.alertTime = Config.AlertTime end
+    
+    if data.time < GetGameTimer() * 1000 then return end
+    
     local timer = data.alertTime * 1000
-
+    
     if not waypointCooldown and lib.table.contains(data.jobs, PlayerData.job.type) then
         SetNewWaypoint(data.coords.x, data.coords.y)
         TriggerServerEvent('ps-dispatch:server:attach', data.id, PlayerData)


### PR DESCRIPTION
Pushing up a potential patch to fix the dispatch issue. This should resolve the issue where you can respond to dispatch notifications long after they've left your screen. This should resolve issue https://github.com/Project-Sloth/ps-dispatch/issues/312